### PR TITLE
16 add contribuiting guidelines

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,0 +1,177 @@
+<!--
+SPDX-FileCopyrightText: 2023 Vasco Guita <vasco@guita.org>
+
+SPDX-License-Identifier: CC-BY-4.0
+-->
+
+# Contributing to Hugo Freedom Theme
+
+First off, thanks for taking the time to contribute! ❤️
+
+All types of contributions are encouraged and valued. See the [Table of Contents](#table-of-contents)
+for different ways to help and details about how this project handles them.
+Please make sure to read the relevant section before making your contribution.
+It will make it a lot easier for us maintainers and smooth out the experience
+for all involved. The community looks forward to your contributions. 🎉
+
+> And if you like the project, but just don't have time to contribute, that's
+> fine. There are other easy ways to support the project and show your
+> appreciation, which we would also be very happy about:
+>
+> - Star the project
+>
+> - Tweet about it
+>
+> - Refer this project in your project's readme
+>
+> - Mention the project at local meetups and tell your friends/colleagues
+
+## Table of Contents
+
+- [Code of Conduct](#code-of-conduct)
+- [I Have a Question](#i-have-a-question)
+- [I Want To Contribute](#i-want-to-contribute)
+- [Reporting Bugs](#reporting-bugs)
+- [Suggesting Enhancements](#suggesting-enhancements)
+
+## Code of Conduct
+
+This project and everyone participating in it is governed by the
+[Hugo Freedom Theme Code of Conduct](./CODE_OF_CONDUCT.md). By participating,
+you are expected to uphold this code. Please report unacceptable behavior to
+<vasco@guita.org>.
+
+## I Have a Question
+
+> If you want to ask a question, we assume that you have read the available [Documentation](https://github.com/vascoguita/freedom/wiki).
+
+Before you ask a question, it is best to search for existing [Issues](https://github.com/vascoguita/freedom/issues)
+that might help you. In case you have found a suitable issue and still need
+clarification, you can write your question in this issue. It is also advisable
+to search the internet for answers first.
+
+If you then still feel the need to ask a question and need clarification, we
+recommend the following:
+
+- Open an [Issue](https://github.com/vascoguita/freedom/issues/new).
+
+- Provide as much context as you can about what you're running into.
+
+We will then take care of the issue as soon as possible.
+
+## I Want To Contribute
+
+> ### Legal Notice
+>
+> When contributing to this project, you must agree that you have authored 100%
+> of the content, that you have the necessary rights to the content and that the
+> content you contribute may be provided under the project license.
+
+### Reporting Bugs
+
+#### Before Submitting a Bug Report
+
+A good bug report shouldn't leave others needing to chase you up for more
+information. Therefore, we ask you to investigate carefully, collect information
+and describe the issue in detail in your report. Please complete the following
+steps in advance to help us fix any potential bug as fast as possible.
+
+- Make sure that you are using the latest version.
+
+- Determine if your bug is really a bug and not an error on your side e.g. using
+  incompatible environment components/versions (Make sure that you have read the
+  [documentation](https://github.com/vascoguita/freedom/wiki). If you are
+  looking for support, you might want to check
+  [this section](#i-have-a-question)).
+
+- To see if other users have experienced (and potentially already solved) the
+  same issue you are having, check if there is not already a bug report existing
+  for your bug or error in the [bug tracker](https://github.com/vascoguita/freedom/issues?q=label%3Abug).
+
+- Also make sure to search the internet (including Stack Overflow) to see if
+  users outside of the GitHub community have discussed the issue.
+
+- Collect information about the bug:
+
+  - Stack trace (Traceback)
+
+  - OS, Platform and Version (Windows, Linux, macOS, x86, ARM).
+
+  - Version of the interpreter, compiler, SDK, runtime environment, package
+    manager, depending on what seems relevant.
+
+  - Possibly your input and the output.
+
+  - Can you reliably reproduce the issue? And can you also reproduce it with
+    older versions?
+
+#### How Do I Submit a Good Bug Report?
+
+> You must never report security related issues, vulnerabilities or bugs
+> including sensitive information to the issue tracker, or elsewhere in public.
+> Instead sensitive bugs must be sent by email to <vasco@guita.org>.
+
+We use GitHub issues to track bugs and errors. If you run into an issue with the
+project:
+
+- Open an [Issue](https://github.com/vascoguita/freedom/issues/new).
+
+- Explain the behavior you would expect and the actual behavior.
+
+- Please provide as much context as possible and describe the *reproduction
+  steps* that someone else can follow to recreate the issue on their own. This
+  usually includes your code. For good bug reports you should isolate the
+  problem and create a reduced test case.
+
+- Provide the information you collected in the previous section.
+
+### Suggesting Enhancements
+
+This section guides you through submitting an enhancement suggestion for Hugo
+Freedom Theme, **including completely new features and minor improvements to
+existing functionality**. Following these guidelines will help maintainers and
+the community to understand your suggestion and find related suggestions.
+
+#### Before Submitting an Enhancement
+
+- Make sure that you are using the latest version.
+
+- Read the [documentation](https://github.com/vascoguita/freedom/wiki) carefully
+  and find out if the functionality is already covered, maybe by an individual
+  configuration.
+
+- Perform a [search](https://github.com/vascoguita/freedom/issues) to see if the
+  enhancement has already been suggested. If it has, add a comment to the
+  existing issue instead of opening a new one.
+
+- Find out whether your idea fits with the scope and aims of the project. It's
+  up to you to make a strong case to convince the project's developers of the
+  merits of this feature. Keep in mind that we want features that will be useful
+  to the majority of our users and not just a small subset. If you're just
+  targeting a minority of users, consider writing an add-on/plugin library.
+
+#### How Do I Submit a Good Enhancement Suggestion?
+
+Enhancement suggestions are tracked as [GitHub issues](https://github.com/vascoguita/freedom/issues).
+
+- Use a **clear and descriptive title** for the issue to identify the
+  suggestion.
+
+- Provide a **step-by-step description of the suggested enhancement** in as many
+  details as possible.
+
+- **Describe the current behavior** and **explain which behavior you expected to
+  see instead** and why. At this point you can also tell which alternatives do
+  not work for you.
+
+- You may want to **include screenshots and animated GIFs** which help you
+  demonstrate the steps or point out the part which the suggestion is related
+  to.
+
+- **Explain why this enhancement would be useful** to most Hugo Freedom Theme
+  users. You may also want to point out the other projects that solved it better
+  and which could serve as inspiration.
+
+## Attribution
+
+This guide is based on the **contributing-gen**. [Make your own](https://github.com/bttger/contributing-gen)!

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,14 +1,14 @@
-<!--
-SPDX-FileCopyrightText: 2023 Vasco Guita <vasco@guita.org>
-
-SPDX-License-Identifier: CC-BY-4.0
--->
+---
+# SPDX-FileCopyrightText: 2023 Vasco Guita <vasco@guita.org>
+#
+# SPDX-License-Identifier: CC-BY-4.0
+---
 
 # Solved issue
 
 Closes #ISSUE-NUMBER
 
-# Summary of changes
+## Summary of changes
 
 -
 -


### PR DESCRIPTION
# Solved issue

Closes #16 

## Summary of changes

- Add contributing guidelines generated with <https://generator.contributing.md>.
- Move pull request template license header to frontmatter.
- Fix "Multiple top-level headings in the same document" markdownlint-cli2 error on the pull request template.
