### PR TITLE
15 add license check

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,8 +1,8 @@
----
-# SPDX-FileCopyrightText: 2023 Vasco Guita <vasco@guita.org>
-#
-# SPDX-License-Identifier: CC-BY-4.0
----
+<!--
+SPDX-FileCopyrightText: 2023 Vasco Guita <vasco@guita.org>
+
+SPDX-License-Identifier: CC-BY-4.0
+-->
 
 # Solved issue
 

--- a/.github/workflows/check-license-headers.yaml
+++ b/.github/workflows/check-license-headers.yaml
@@ -1,0 +1,17 @@
+---
+# SPDX-FileCopyrightText: 2023 Vasco Guita <vasco@guita.org>
+#
+# SPDX-License-Identifier: MIT
+
+name: Check License Headers
+
+on: [push, pull_request, workflow_dispatch]  # yamllint disable-line rule:truthy
+
+jobs:
+  check-license-headers:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Check License Headers
+        uses: apache/skywalking-eyes/header@v0.5.0

--- a/.licenserc.yaml
+++ b/.licenserc.yaml
@@ -1,0 +1,27 @@
+---
+# SPDX-FileCopyrightText: 2023 Vasco Guita <vasco@guita.org>
+#
+# SPDX-License-Identifier: MIT
+
+header:
+  - license:
+      spdx-id: MIT
+      content: |
+        SPDX-FileCopyrightText: 2023 Vasco Guita <vasco@guita.org>
+
+        SPDX-License-Identifier: MIT
+    paths-ignore:
+      - '**/*.md'
+      - 'LICENSE'
+    license-location-threshold: 1
+    comment: on-failure
+  - license:
+      spdx-id: CC-BY-4.0
+      content: |
+        SPDX-FileCopyrightText: 2023 Vasco Guita <vasco@guita.org>
+
+        SPDX-License-Identifier: CC-BY-4.0
+    paths:
+      - '**/*.md'
+    license-location-threshold: 1
+    comment: on-failure

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@
 all: test
 
 .PHONY: test
-test: lint-yaml lint-markdown lint-makefile
+test: lint-yaml lint-markdown lint-makefile check-license-headers
 
 .PHONY: lint-yaml
 lint-yaml:
@@ -19,6 +19,10 @@ lint-markdown:
 .PHONY: lint-makefile
 lint-makefile:
 	checkmake Makefile
+
+.PHONY: check-license-headers
+check-license-headers:
+	license-eye header check
 
 .PHONY: clean
 clean:


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2023 Vasco Guita <vasco@guita.org>

SPDX-License-Identifier: CC-BY-4.0
-->

# Solved issue

Closes #15 

## Summary of changes

- Add GitHub Action to check license headers with Apache SkyWalking Eyes[^1].
- Add Makefile rule to check license headers with Apache SkyWalking Eyes.
- Add Apache SkyWalking Eyes configuration to check both MIT and CC-BY-4.0 license headers.
- Fix pull request template license header.

[^1]: https://github.com/apache/skywalking-eyes